### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/bench/statistics.py
+++ b/bench/statistics.py
@@ -190,7 +190,7 @@ def _check_type(T, allowed):
             allowed.add(T)
         else:
             types = ', '.join([t.__name__ for t in allowed] + [T.__name__])
-            raise TypeError("unsupported mixed types: %s" % types)
+            raise TypeError("unsupported mixed types: {0!s}".format(types))
 
 
 def _exact_ratio(x):
@@ -396,7 +396,7 @@ def median_grouped(data, interval=1):
     x = data[n//2]
     for obj in (x, interval):
         if isinstance(obj, (str, bytes)):
-            raise TypeError('expected number but got %r' % obj)
+            raise TypeError('expected number but got {0!r}'.format(obj))
     try:
         L = x - interval/2  # The lower limit of the median interval.
     except TypeError:
@@ -431,7 +431,7 @@ def mode(data):
         return table[0][0]
     elif table:
         raise StatisticsError(
-                'no unique mode; found %d equally common values' % len(table)
+                'no unique mode; found {0:d} equally common values'.format(len(table))
                 )
     else:
         raise StatisticsError('no mode for empty data')
@@ -464,7 +464,7 @@ def _ss(data, c=None):
     # The following sum should mathematically equal zero, but due to rounding
     # error may not.
     ss -= _sum((x-c) for x in data)**2/len(data)
-    assert not ss < 0, 'negative sum of square deviations: %f' % ss
+    assert not ss < 0, 'negative sum of square deviations: {0:f}'.format(ss)
     return ss
 
 

--- a/bench/stats.py
+++ b/bench/stats.py
@@ -13,7 +13,6 @@ def pairs(l, n):
 
 values = [ float(y) - float(x) for (x,y) in pairs(sys.stdin.readlines(),2)]
 
-print("mean = %.4f, median = %.4f, stdev = %.4f" %
-    (statistics.mean(values), statistics.median(values),
+print("mean = {0:.4f}, median = {1:.4f}, stdev = {2:.4f}".format(statistics.mean(values), statistics.median(values),
       statistics.stdev(values)))
 

--- a/test/pathological_tests.py
+++ b/test/pathological_tests.py
@@ -66,7 +66,7 @@ for description in pathological:
     [rc, actual, err] = cmark.to_html(inp)
     if rc != 0:
         errored += 1
-        print(description, '[ERRORED (return code %d)]' %rc)
+        print(description, '[ERRORED (return code {0:d})]'.format(rc))
         print(err)
     elif regex.search(actual):
         print(description, '[PASSED]')
@@ -76,7 +76,7 @@ for description in pathological:
         print(repr(actual))
         failed += 1
 
-print("%d passed, %d failed, %d errored" % (passed, failed, errored))
+print("{0:d} passed, {1:d} failed, {2:d} errored".format(passed, failed, errored))
 if (failed == 0 and errored == 0):
     exit(0)
 else:

--- a/test/spec_tests.py
+++ b/test/spec_tests.py
@@ -36,7 +36,7 @@ def out(str):
     sys.stdout.buffer.write(str.encode('utf-8')) 
 
 def print_test_header(headertext, example_number, start_line, end_line):
-    out("Example %d (lines %d-%d) %s\n" % (example_number,start_line,end_line,headertext))
+    out("Example {0:d} (lines {1:d}-{2:d}) {3!s}\n".format(example_number, start_line, end_line, headertext))
 
 def do_test(test, normalize, result_counts):
     [retcode, actual_html, err] = cmark.to_html(test['markdown'])
@@ -70,7 +70,7 @@ def do_test(test, normalize, result_counts):
             result_counts['fail'] += 1
     else:
         print_test_header(test['section'], test['example'], test['start_line'], test['end_line'])
-        out("program returned error code %d\n" % retcode)
+        out("program returned error code {0:d}\n".format(retcode))
         sys.stdout.buffer.write(err)
         result_counts['error'] += 1
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:swift-cmark?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:swift-cmark?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
